### PR TITLE
docs: showcase the curated sales library

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,16 @@
 - **紧迫性必须真实**：只有存在名额、价格调整、截止日期、供给能力或明确机会成本时才使用，不虚构稀缺。
 - **默认保留销售者自己的声音**：给判断、表达任务和动作，除非明确请求，否则不代写整段话术。
 
+## 资料库：204 项研究目录，403 份高相关资料
+
+销冠先建立了 **204 项书籍、课程、报告、法规与标准目录**，再对本地语料做相关性精简：从 **34,486,518** 个 Unicode 字符的候选池，优化到当前 **16,802,204** 个字符，减少 **51.3%**，保留 **403** 份高相关资料，建成 **15,473** 个可检索分片。
+
+<a href="./assets/library-catalog.svg">
+  <img src="./assets/library-catalog.svg" alt="销冠资料库204项完整研究目录与精简统计">
+</a>
+
+204 项是研究书目/课程目录索引，不代表付费商业作品全文被纳入公开仓库。[**查看完整文字目录 →**](./docs/library-catalog.md)
+
 ## 快速开始
 
 ### 1. 安装 Skill
@@ -156,6 +166,8 @@ python3 scripts/search_corpus.py \
 xiaoguan/
 ├── SKILL.md                         # 主入口、请求路由与输出规则
 ├── agents/openai.yaml               # Codex 界面元数据
+├── assets/library-catalog.svg        # 204 项资料库全景图
+├── docs/library-catalog.md           # 完整可搜索文字目录
 ├── references/
 │   ├── decision-analysis.md         # 客户画像与决策权重
 │   ├── persuasion-engine.md         # 确信、欲望、紧迫性与成交
@@ -192,10 +204,6 @@ xiaoguan/
 ## 参与项目
 
 如果你发现某类客户判断不准、销售阶段路由不合适，或有可复现的改进建议，欢迎提交 [Issue](https://github.com/powerycy/xiaoguan/issues) 或 Pull Request。请不要在 Issue 中上传真实客户姓名、联系方式、聊天全文或商业机密。
-
-## 许可证
-
-本仓库目前未提供 `LICENSE` 文件，因此不要把它视为已获得 OSI 开源许可或默认商业授权。后续许可证将以仓库实际文件为准。
 
 ---
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -63,6 +63,16 @@ This is an internal reasoning sequence, not a mandatory output template. A narro
 - **Urgency must be real.** Capacity, price changes, deadlines, supply constraints, or delay costs are used only when they actually exist.
 - **The seller keeps their own voice.** Direction and action are the default; complete scripts require an explicit request.
 
+## Library: 204 research titles, 403 high-relevance sources
+
+Xiaoguan first catalogued **204 books, courses, reports, regulations, and standards**, then curated the local corpus for sales relevance. The candidate pool was reduced from **34,486,518** to **16,802,204 Unicode characters** (−**51.3%**), retaining **403** high-relevance sources and producing **15,473** searchable chunks.
+
+<a href="./assets/library-catalog.svg">
+  <img src="./assets/library-catalog.svg" alt="Xiaoguan complete 204-title research catalog and corpus curation metrics">
+</a>
+
+The 204 entries are a research bibliography and course catalog; they do not mean that full copies of paid commercial works are included in this public repository. [**Open the complete text catalog →**](./docs/library-catalog.md)
+
 ## Quick start
 
 ### 1. Install the Skill
@@ -156,6 +166,8 @@ Hybrid indexing requires Python 3.10+, `numpy`, `fastembed`, and local copies of
 xiaoguan/
 ├── SKILL.md                         # Entry point, request routing, output rules
 ├── agents/openai.yaml               # Codex interface metadata
+├── assets/library-catalog.svg        # Visual map of all 204 catalog entries
+├── docs/library-catalog.md           # Complete searchable text catalog
 ├── references/
 │   ├── decision-analysis.md         # Buyer profiles and decision weights
 │   ├── persuasion-engine.md         # Belief, desire, urgency, and closing
@@ -192,10 +204,6 @@ The project does not currently publish CI, Releases, or coverage metrics, so thi
 ## Contributing
 
 If a buyer analysis is consistently wrong, a stage is routed poorly, or you have a reproducible improvement, open an [Issue](https://github.com/powerycy/xiaoguan/issues) or submit a Pull Request. Do not include real customer names, contact details, full private conversations, or confidential business information.
-
-## License
-
-This repository currently has no `LICENSE` file. Do not treat it as OSI-licensed open source or as granting commercial-use rights. Any future license terms will be defined by the actual repository files.
 
 ---
 

--- a/assets/library-catalog.svg
+++ b/assets/library-catalog.svg
@@ -1,0 +1,290 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1800" height="2477" viewBox="0 0 1800 2477">
+<rect width="100%" height="100%" fill="#F8FAFC"/>
+<style>text{font-family:Inter,-apple-system,BlinkMacSystemFont,"Segoe UI","PingFang SC","Microsoft YaHei",Arial,sans-serif}.mono{font-family:"SFMono-Regular",Consolas,"Liberation Mono",monospace}</style>
+<text x="72" y="88" font-size="42" font-weight="760" fill="#111827">销冠资料库·完整研究目录</text>
+<text x="72" y="128" font-size="18" fill="#475569">XIAOGUAN LIBRARY MAP  ·  204 项全量书籍 / 课程 / 报告 / 法规 / 标准目录</text>
+<rect x="72.0" y="170" width="400.5" height="120" rx="16" fill="#FFFFFF" stroke="#CBD5E1"/>
+<text x="96.0" y="223" font-size="34" font-weight="760" fill="#1D4ED8">204</text>
+<text x="96.0" y="257" font-size="13" letter-spacing="0.6" fill="#64748B">目录条目 · UNIQUE TITLES</text>
+<rect x="490.5" y="170" width="400.5" height="120" rx="16" fill="#FFFFFF" stroke="#CBD5E1"/>
+<text x="514.5" y="223" font-size="34" font-weight="760" fill="#1D4ED8">403</text>
+<text x="514.5" y="257" font-size="13" letter-spacing="0.6" fill="#64748B">保留资料 · RETAINED SOURCES</text>
+<rect x="909.0" y="170" width="400.5" height="120" rx="16" fill="#FFFFFF" stroke="#CBD5E1"/>
+<text x="933.0" y="223" font-size="25" font-weight="760" fill="#1D4ED8">3,448.65万 → 1,680.22万</text>
+<text x="933.0" y="257" font-size="13" letter-spacing="0.6" fill="#64748B">UNICODE 字符 · CURATED CORPUS</text>
+<rect x="1327.5" y="170" width="400.5" height="120" rx="16" fill="#FFFFFF" stroke="#CBD5E1"/>
+<text x="1351.5" y="223" font-size="34" font-weight="760" fill="#1D4ED8">−51.3%</text>
+<text x="1351.5" y="257" font-size="13" letter-spacing="0.6" fill="#64748B">去冗减负 · CORPUS REDUCTION</text>
+<text x="72" y="326" font-size="15" fill="#475569">当前语料：16,802,204 字符 · 15,473 可检索分片 · 精准统计截至 2026-08-25</text>
+<text x="72" y="354" font-size="14" fill="#64748B">注：204项为研究目录索引，不代表付费商业作品全文；公开仓库不包含本地语料本体。</text>
+<rect x="72.0" y="390.0" width="396.0" height="576.0" rx="14" fill="#FFFFFF" stroke="#D8E0EA"/>
+<rect x="72.0" y="390.0" width="6" height="576.0" rx="3" fill="#2563EB"/>
+<text x="94.0" y="425.0" font-size="18" font-weight="700" fill="#0F172A">行为决策与心理</text>
+<text x="446.0" y="425.0" text-anchor="end" font-size="13" class="mono" fill="#64748B">20 ITEMS</text>
+<text x="94.0" y="457.0" font-size="13.5" font-weight="540" fill="#334155">001  Thinking, Fast and Slow</text>
+<text x="94.0" y="482.0" font-size="13.5" font-weight="540" fill="#334155">002  Nudge</text>
+<text x="94.0" y="507.0" font-size="13.5" font-weight="540" fill="#334155">003  Predictably Irrational</text>
+<text x="94.0" y="532.0" font-size="13.5" font-weight="540" fill="#334155">004  The Righteous Mind</text>
+<text x="94.0" y="557.0" font-size="13.5" font-weight="540" fill="#334155">005  How Minds Change</text>
+<text x="94.0" y="582.0" font-size="13.5" font-weight="540" fill="#334155">006  A Theory of Cognitive Dissonance</text>
+<text x="94.0" y="607.0" font-size="13.5" font-weight="540" fill="#334155">007  The Social Animal</text>
+<text x="94.0" y="632.0" font-size="13.5" font-weight="540" fill="#334155">008  Social Beings</text>
+<text x="94.0" y="657.0" font-size="13.5" font-weight="540" fill="#334155">009  Presence</text>
+<text x="94.0" y="682.0" font-size="13.5" font-weight="540" fill="#334155">010  Self-Efficacy</text>
+<text x="94.0" y="707.0" font-size="13.5" font-weight="540" fill="#334155">011  Mindset</text>
+<text x="94.0" y="732.0" font-size="13.5" font-weight="540" fill="#334155">012  Grit</text>
+<text x="94.0" y="757.0" font-size="13.5" font-weight="540" fill="#334155">013  Drive</text>
+<text x="94.0" y="782.0" font-size="13.5" font-weight="540" fill="#334155">014  To Sell Is Human</text>
+<text x="94.0" y="807.0" font-size="13.5" font-weight="540" fill="#334155">015  Behave</text>
+<text x="94.0" y="832.0" font-size="13.5" font-weight="540" fill="#334155">016  The Status Game</text>
+<text x="94.0" y="857.0" font-size="13.5" font-weight="540" fill="#334155">017  Games People Play</text>
+<text x="94.0" y="882.0" font-size="13.5" font-weight="540" fill="#334155">018  Fooled by Randomness</text>
+<text x="94.0" y="907.0" font-size="13.5" font-weight="540" fill="#334155">019  Superforecasting</text>
+<text x="94.0" y="932.0" font-size="13.5" font-weight="540" fill="#334155">020  Thinking in Bets</text>
+<rect x="492.0" y="390.0" width="396.0" height="471.0" rx="14" fill="#FFFFFF" stroke="#D8E0EA"/>
+<rect x="492.0" y="390.0" width="6" height="471.0" rx="3" fill="#2563EB"/>
+<text x="514.0" y="425.0" font-size="18" font-weight="700" fill="#0F172A">组织、权力与变革</text>
+<text x="866.0" y="425.0" text-anchor="end" font-size="13" class="mono" fill="#64748B">15 ITEMS</text>
+<text x="514.0" y="457.0" font-size="13.5" font-weight="540" fill="#334155">021  Power: Why Some People Have It—and</text>
+<text x="514.0" y="477.0" font-size="13.5" font-weight="420" fill="#475569">Others Don’t</text>
+<text x="514.0" y="502.0" font-size="13.5" font-weight="540" fill="#334155">022  7 Rules of Power</text>
+<text x="514.0" y="527.0" font-size="13.5" font-weight="540" fill="#334155">023  Influence Without Authority</text>
+<text x="514.0" y="552.0" font-size="13.5" font-weight="540" fill="#334155">024  Power and Influence</text>
+<text x="514.0" y="577.0" font-size="13.5" font-weight="540" fill="#334155">025  The First 90 Days</text>
+<text x="514.0" y="602.0" font-size="13.5" font-weight="540" fill="#334155">026  Flying Without a Net</text>
+<text x="514.0" y="627.0" font-size="13.5" font-weight="540" fill="#334155">027  Working Identity</text>
+<text x="514.0" y="652.0" font-size="13.5" font-weight="540" fill="#334155">028  Forget a Mentor, Find a Sponsor</text>
+<text x="514.0" y="677.0" font-size="13.5" font-weight="540" fill="#334155">029  Never Eat Alone</text>
+<text x="514.0" y="702.0" font-size="13.5" font-weight="540" fill="#334155">030  Give and Take</text>
+<text x="514.0" y="727.0" font-size="13.5" font-weight="540" fill="#334155">031  Structural Holes</text>
+<text x="514.0" y="752.0" font-size="13.5" font-weight="540" fill="#334155">032  Organizational Culture and Leadership</text>
+<text x="514.0" y="777.0" font-size="13.5" font-weight="540" fill="#334155">033  Overcoming Organizational Defenses</text>
+<text x="514.0" y="802.0" font-size="13.5" font-weight="540" fill="#334155">034  Immunity to Change</text>
+<text x="514.0" y="827.0" font-size="13.5" font-weight="540" fill="#334155">035  Leading Change</text>
+<rect x="912.0" y="390.0" width="396.0" height="501.0" rx="14" fill="#FFFFFF" stroke="#D8E0EA"/>
+<rect x="912.0" y="390.0" width="6" height="501.0" rx="3" fill="#2563EB"/>
+<text x="934.0" y="425.0" font-size="18" font-weight="700" fill="#0F172A">顾问式销售与价值</text>
+<text x="1286.0" y="425.0" text-anchor="end" font-size="13" class="mono" fill="#64748B">17 ITEMS</text>
+<text x="934.0" y="457.0" font-size="13.5" font-weight="540" fill="#334155">036  SPIN Selling Fieldbook</text>
+<text x="934.0" y="482.0" font-size="13.5" font-weight="540" fill="#334155">037  Questions That Sell</text>
+<text x="934.0" y="507.0" font-size="13.5" font-weight="540" fill="#334155">038  Secrets of Question-Based Selling</text>
+<text x="934.0" y="532.0" font-size="13.5" font-weight="540" fill="#334155">039  Insight Selling</text>
+<text x="934.0" y="557.0" font-size="13.5" font-weight="540" fill="#334155">040  Rainmaking Conversations</text>
+<text x="934.0" y="582.0" font-size="13.5" font-weight="540" fill="#334155">041  The Only Sales Guide You’ll Ever Need</text>
+<text x="934.0" y="607.0" font-size="13.5" font-weight="540" fill="#334155">042  Elite Sales Strategies</text>
+<text x="934.0" y="632.0" font-size="13.5" font-weight="540" fill="#334155">043  The Qualified Sales Leader</text>
+<text x="934.0" y="657.0" font-size="13.5" font-weight="540" fill="#334155">044  Command of the Message</text>
+<text x="934.0" y="682.0" font-size="13.5" font-weight="540" fill="#334155">045  The Science of Selling</text>
+<text x="934.0" y="707.0" font-size="13.5" font-weight="540" fill="#334155">046  Sales Presentations for Dummies</text>
+<text x="934.0" y="732.0" font-size="13.5" font-weight="540" fill="#334155">047  Sell Different!</text>
+<text x="934.0" y="757.0" font-size="13.5" font-weight="540" fill="#334155">048  How Clients Buy</text>
+<text x="934.0" y="782.0" font-size="13.5" font-weight="540" fill="#334155">049  Power Questions</text>
+<text x="934.0" y="807.0" font-size="13.5" font-weight="540" fill="#334155">050  Clients for Life</text>
+<text x="934.0" y="832.0" font-size="13.5" font-weight="540" fill="#334155">051  The Win Without Pitching Manifesto</text>
+<text x="934.0" y="857.0" font-size="13.5" font-weight="540" fill="#334155">052  Pricing Creativity</text>
+<rect x="1332.0" y="390.0" width="396.0" height="276.0" rx="14" fill="#FFFFFF" stroke="#D8E0EA"/>
+<rect x="1332.0" y="390.0" width="6" height="276.0" rx="3" fill="#2563EB"/>
+<text x="1354.0" y="425.0" font-size="18" font-weight="700" fill="#0F172A">大客户与采购</text>
+<text x="1706.0" y="425.0" text-anchor="end" font-size="13" class="mono" fill="#64748B">08 ITEMS</text>
+<text x="1354.0" y="457.0" font-size="13.5" font-weight="540" fill="#334155">053  Key Account Management</text>
+<text x="1354.0" y="482.0" font-size="13.5" font-weight="540" fill="#334155">054  Key Account Planning</text>
+<text x="1354.0" y="507.0" font-size="13.5" font-weight="540" fill="#334155">055  Key Account Management and Planning</text>
+<text x="1354.0" y="532.0" font-size="13.5" font-weight="540" fill="#334155">056  Handbook of Strategic Account Management</text>
+<text x="1354.0" y="557.0" font-size="13.5" font-weight="540" fill="#334155">057  Strategic Selling</text>
+<text x="1354.0" y="582.0" font-size="13.5" font-weight="540" fill="#334155">058  Beyond the Sales Process</text>
+<text x="1354.0" y="607.0" font-size="13.5" font-weight="540" fill="#334155">059  Supplier Relationship Management</text>
+<text x="1354.0" y="632.0" font-size="13.5" font-weight="540" fill="#334155">060  Category Management in Purchasing</text>
+<rect x="1332.0" y="686.0" width="396.0" height="546.0" rx="14" fill="#FFFFFF" stroke="#D8E0EA"/>
+<rect x="1332.0" y="686.0" width="6" height="546.0" rx="3" fill="#2563EB"/>
+<text x="1354.0" y="721.0" font-size="18" font-weight="700" fill="#0F172A">谈判、定价与成交</text>
+<text x="1706.0" y="721.0" text-anchor="end" font-size="13" class="mono" fill="#64748B">18 ITEMS</text>
+<text x="1354.0" y="753.0" font-size="13.5" font-weight="540" fill="#334155">061  Bargaining for Advantage</text>
+<text x="1354.0" y="778.0" font-size="13.5" font-weight="540" fill="#334155">062  Negotiation Genius</text>
+<text x="1354.0" y="803.0" font-size="13.5" font-weight="540" fill="#334155">063  Getting Past No</text>
+<text x="1354.0" y="828.0" font-size="13.5" font-weight="540" fill="#334155">064  The Power of a Positive No</text>
+<text x="1354.0" y="853.0" font-size="13.5" font-weight="540" fill="#334155">065  Negotiating for Success</text>
+<text x="1354.0" y="878.0" font-size="13.5" font-weight="540" fill="#334155">066  You Can Negotiate Anything</text>
+<text x="1354.0" y="903.0" font-size="13.5" font-weight="540" fill="#334155">067  Start with No</text>
+<text x="1354.0" y="928.0" font-size="13.5" font-weight="540" fill="#334155">068  Secrets of Power Negotiating</text>
+<text x="1354.0" y="953.0" font-size="13.5" font-weight="540" fill="#334155">069  Negotiating with Backbone</text>
+<text x="1354.0" y="978.0" font-size="13.5" font-weight="540" fill="#334155">070  Confessions of the Pricing Man</text>
+<text x="1354.0" y="1003.0" font-size="13.5" font-weight="540" fill="#334155">071  Monetizing Innovation</text>
+<text x="1354.0" y="1028.0" font-size="13.5" font-weight="540" fill="#334155">072  The Strategy and Tactics of Pricing</text>
+<text x="1354.0" y="1053.0" font-size="13.5" font-weight="540" fill="#334155">073  Objections</text>
+<text x="1354.0" y="1078.0" font-size="13.5" font-weight="540" fill="#334155">074  Sales EQ</text>
+<text x="1354.0" y="1103.0" font-size="13.5" font-weight="540" fill="#334155">075  Ink the Deal</text>
+<text x="1354.0" y="1128.0" font-size="13.5" font-weight="540" fill="#334155">076  Secrets of Closing the Sale</text>
+<text x="1354.0" y="1153.0" font-size="13.5" font-weight="540" fill="#334155">077  How to Master the Art of Selling</text>
+<text x="1354.0" y="1178.0" font-size="13.5" font-weight="540" fill="#334155">078  How I Raised Myself from Failure to</text>
+<text x="1354.0" y="1198.0" font-size="13.5" font-weight="420" fill="#475569">Success in Selling</text>
+<rect x="492.0" y="881.0" width="396.0" height="376.0" rx="14" fill="#FFFFFF" stroke="#D8E0EA"/>
+<rect x="492.0" y="881.0" width="6" height="376.0" rx="3" fill="#2563EB"/>
+<text x="514.0" y="916.0" font-size="18" font-weight="700" fill="#0F172A">销售心理与直销</text>
+<text x="866.0" y="916.0" text-anchor="end" font-size="13" class="mono" fill="#64748B">12 ITEMS</text>
+<text x="514.0" y="948.0" font-size="13.5" font-weight="540" fill="#334155">079  Way of the Wolf</text>
+<text x="514.0" y="973.0" font-size="13.5" font-weight="540" fill="#334155">080  The Psychology of Selling</text>
+<text x="514.0" y="998.0" font-size="13.5" font-weight="540" fill="#334155">081  Advanced Selling Strategies</text>
+<text x="514.0" y="1023.0" font-size="13.5" font-weight="540" fill="#334155">082  Sell or Be Sold</text>
+<text x="514.0" y="1048.0" font-size="13.5" font-weight="540" fill="#334155">083  The Closer’s Survival Guide</text>
+<text x="514.0" y="1073.0" font-size="13.5" font-weight="540" fill="#334155">084  The 10X Rule</text>
+<text x="514.0" y="1098.0" font-size="13.5" font-weight="540" fill="#334155">085  The Little Red Book of Selling</text>
+<text x="514.0" y="1123.0" font-size="13.5" font-weight="540" fill="#334155">086  How to Sell Anything to Anybody</text>
+<text x="514.0" y="1148.0" font-size="13.5" font-weight="540" fill="#334155">087  The Greatest Salesman in the World</text>
+<text x="514.0" y="1173.0" font-size="13.5" font-weight="540" fill="#334155">088  No Thanks, I’m Just Looking</text>
+<text x="514.0" y="1198.0" font-size="13.5" font-weight="540" fill="#334155">089  The Psychology of Persuasion</text>
+<text x="514.0" y="1223.0" font-size="13.5" font-weight="540" fill="#334155">090  Direct Selling for Dummies</text>
+<rect x="912.0" y="911.0" width="396.0" height="251.0" rx="14" fill="#FFFFFF" stroke="#D8E0EA"/>
+<rect x="912.0" y="911.0" width="6" height="251.0" rx="3" fill="#2563EB"/>
+<text x="934.0" y="946.0" font-size="18" font-weight="700" fill="#0F172A">中国商业与关系</text>
+<text x="1286.0" y="946.0" text-anchor="end" font-size="13" class="mono" fill="#64748B">07 ITEMS</text>
+<text x="934.0" y="978.0" font-size="13.5" font-weight="540" fill="#334155">091  Capitalism with Chinese Characteristics</text>
+<text x="934.0" y="1003.0" font-size="13.5" font-weight="540" fill="#334155">092  China’s Gilded Age</text>
+<text x="934.0" y="1028.0" font-size="13.5" font-weight="540" fill="#334155">093  How China Escaped the Poverty Trap</text>
+<text x="934.0" y="1053.0" font-size="13.5" font-weight="540" fill="#334155">094  Chinese Business Negotiating Style</text>
+<text x="934.0" y="1078.0" font-size="13.5" font-weight="540" fill="#334155">095  Guanxi and Business</text>
+<text x="934.0" y="1103.0" font-size="13.5" font-weight="540" fill="#334155">096  Chinese Commercial Negotiating Style</text>
+<text x="934.0" y="1128.0" font-size="13.5" font-weight="540" fill="#334155">097  The Culture Map</text>
+<rect x="72.0" y="986.0" width="396.0" height="551.0" rx="14" fill="#FFFFFF" stroke="#D8E0EA"/>
+<rect x="72.0" y="986.0" width="6" height="551.0" rx="3" fill="#2563EB"/>
+<text x="94.0" y="1021.0" font-size="18" font-weight="700" fill="#0F172A">内容、品牌与 ABM</text>
+<text x="446.0" y="1021.0" text-anchor="end" font-size="13" class="mono" fill="#64748B">19 ITEMS</text>
+<text x="94.0" y="1053.0" font-size="13.5" font-weight="540" fill="#334155">098  The New Rules of Marketing and PR</text>
+<text x="94.0" y="1078.0" font-size="13.5" font-weight="540" fill="#334155">099  They Ask, You Answer</text>
+<text x="94.0" y="1103.0" font-size="13.5" font-weight="540" fill="#334155">100  Everybody Writes</text>
+<text x="94.0" y="1128.0" font-size="13.5" font-weight="540" fill="#334155">101  Epic Content Marketing</text>
+<text x="94.0" y="1153.0" font-size="13.5" font-weight="540" fill="#334155">102  Content Inc</text>
+<text x="94.0" y="1178.0" font-size="13.5" font-weight="540" fill="#334155">103  Managing Content Marketing</text>
+<text x="94.0" y="1203.0" font-size="13.5" font-weight="540" fill="#334155">104  Building a StoryBrand</text>
+<text x="94.0" y="1228.0" font-size="13.5" font-weight="540" fill="#334155">105  Contagious</text>
+<text x="94.0" y="1253.0" font-size="13.5" font-weight="540" fill="#334155">106  Jab, Jab, Jab, Right Hook</text>
+<text x="94.0" y="1278.0" font-size="13.5" font-weight="540" fill="#334155">107  Social Selling</text>
+<text x="94.0" y="1303.0" font-size="13.5" font-weight="540" fill="#334155">108  Social Selling Mastery</text>
+<text x="94.0" y="1328.0" font-size="13.5" font-weight="540" fill="#334155">109  Full Funnel Marketing</text>
+<text x="94.0" y="1353.0" font-size="13.5" font-weight="540" fill="#334155">110  Account-Based Marketing for Dummies</text>
+<text x="94.0" y="1378.0" font-size="13.5" font-weight="540" fill="#334155">111  ABM Is B2B</text>
+<text x="94.0" y="1403.0" font-size="13.5" font-weight="540" fill="#334155">112  The ABM Effect</text>
+<text x="94.0" y="1428.0" font-size="13.5" font-weight="540" fill="#334155">113  Lost and Founder</text>
+<text x="94.0" y="1453.0" font-size="13.5" font-weight="540" fill="#334155">114  How Brands Grow</text>
+<text x="94.0" y="1478.0" font-size="13.5" font-weight="540" fill="#334155">115  Building Distinctive Brand Assets</text>
+<text x="94.0" y="1503.0" font-size="13.5" font-weight="540" fill="#334155">116  The Long and the Short of It</text>
+<rect x="912.0" y="1182.0" width="396.0" height="326.0" rx="14" fill="#FFFFFF" stroke="#D8E0EA"/>
+<rect x="912.0" y="1182.0" width="6" height="326.0" rx="3" fill="#2563EB"/>
+<text x="934.0" y="1217.0" font-size="18" font-weight="700" fill="#0F172A">销售增长与 RevOps</text>
+<text x="1286.0" y="1217.0" text-anchor="end" font-size="13" class="mono" fill="#64748B">10 ITEMS</text>
+<text x="934.0" y="1249.0" font-size="13.5" font-weight="540" fill="#334155">117  Predictable Revenue</text>
+<text x="934.0" y="1274.0" font-size="13.5" font-weight="540" fill="#334155">118  The Sales Acceleration Formula</text>
+<text x="934.0" y="1299.0" font-size="13.5" font-weight="540" fill="#334155">119  Blueprints for a SaaS Sales Organization</text>
+<text x="934.0" y="1324.0" font-size="13.5" font-weight="540" fill="#334155">120  Revenue Operations</text>
+<text x="934.0" y="1349.0" font-size="13.5" font-weight="540" fill="#334155">121  Predictable Prospecting</text>
+<text x="934.0" y="1374.0" font-size="13.5" font-weight="540" fill="#334155">122  The Sales Development Playbook</text>
+<text x="934.0" y="1399.0" font-size="13.5" font-weight="540" fill="#334155">123  New Sales. Simplified</text>
+<text x="934.0" y="1424.0" font-size="13.5" font-weight="540" fill="#334155">124  Sales Truth</text>
+<text x="934.0" y="1449.0" font-size="13.5" font-weight="540" fill="#334155">125  State of Sales, 7th Edition</text>
+<text x="934.0" y="1474.0" font-size="13.5" font-weight="540" fill="#334155">126  2026 Global B2B Pulse</text>
+<rect x="1332.0" y="1252.0" width="396.0" height="516.0" rx="14" fill="#FFFFFF" stroke="#D8E0EA"/>
+<rect x="1332.0" y="1252.0" width="6" height="516.0" rx="3" fill="#2563EB"/>
+<text x="1354.0" y="1287.0" font-size="18" font-weight="700" fill="#0F172A">客户成功与体验</text>
+<text x="1706.0" y="1287.0" text-anchor="end" font-size="13" class="mono" fill="#64748B">16 ITEMS</text>
+<text x="1354.0" y="1319.0" font-size="13.5" font-weight="540" fill="#334155">127  Customer Success</text>
+<text x="1354.0" y="1344.0" font-size="13.5" font-weight="540" fill="#334155">128  Customer Success: How Innovative</text>
+<text x="1354.0" y="1364.0" font-size="13.5" font-weight="420" fill="#475569">Companies Are Reducing Churn</text>
+<text x="1354.0" y="1389.0" font-size="13.5" font-weight="540" fill="#334155">129  Customer Success: The Book</text>
+<text x="1354.0" y="1414.0" font-size="13.5" font-weight="540" fill="#334155">130  The Customer Success Professional’s</text>
+<text x="1354.0" y="1434.0" font-size="13.5" font-weight="420" fill="#475569">Handbook</text>
+<text x="1354.0" y="1459.0" font-size="13.5" font-weight="540" fill="#334155">131  Practical Customer Success Management</text>
+<text x="1354.0" y="1484.0" font-size="13.5" font-weight="540" fill="#334155">132  Onboarding Matters</text>
+<text x="1354.0" y="1509.0" font-size="13.5" font-weight="540" fill="#334155">133  Never Lose a Customer Again</text>
+<text x="1354.0" y="1534.0" font-size="13.5" font-weight="540" fill="#334155">134  Chief Customer Officer 2.0</text>
+<text x="1354.0" y="1559.0" font-size="13.5" font-weight="540" fill="#334155">135  Customer Experience 3.0</text>
+<text x="1354.0" y="1584.0" font-size="13.5" font-weight="540" fill="#334155">136  Strategic Customer Service</text>
+<text x="1354.0" y="1609.0" font-size="13.5" font-weight="540" fill="#334155">137  The Loyalty Effect</text>
+<text x="1354.0" y="1634.0" font-size="13.5" font-weight="540" fill="#334155">138  Winning on Purpose</text>
+<text x="1354.0" y="1659.0" font-size="13.5" font-weight="540" fill="#334155">139  The Effortless Experience</text>
+<text x="1354.0" y="1684.0" font-size="13.5" font-weight="540" fill="#334155">140  Uplifting Service</text>
+<text x="1354.0" y="1709.0" font-size="13.5" font-weight="540" fill="#334155">141  Unreasonable Hospitality</text>
+<text x="1354.0" y="1734.0" font-size="13.5" font-weight="540" fill="#334155">142  Kaleidoscope</text>
+<rect x="492.0" y="1277.0" width="396.0" height="501.0" rx="14" fill="#FFFFFF" stroke="#D8E0EA"/>
+<rect x="492.0" y="1277.0" width="6" height="501.0" rx="3" fill="#2563EB"/>
+<text x="514.0" y="1312.0" font-size="18" font-weight="700" fill="#0F172A">表达、呈现与沟通</text>
+<text x="866.0" y="1312.0" text-anchor="end" font-size="13" class="mono" fill="#64748B">17 ITEMS</text>
+<text x="514.0" y="1344.0" font-size="13.5" font-weight="540" fill="#334155">143  The Pyramid Principle</text>
+<text x="514.0" y="1369.0" font-size="13.5" font-weight="540" fill="#334155">144  Resonate</text>
+<text x="514.0" y="1394.0" font-size="13.5" font-weight="540" fill="#334155">145  Slide:ology</text>
+<text x="514.0" y="1419.0" font-size="13.5" font-weight="540" fill="#334155">146  DataStory</text>
+<text x="514.0" y="1444.0" font-size="13.5" font-weight="540" fill="#334155">147  Storytelling with Data</text>
+<text x="514.0" y="1469.0" font-size="13.5" font-weight="540" fill="#334155">148  Presentation Zen</text>
+<text x="514.0" y="1494.0" font-size="13.5" font-weight="540" fill="#334155">149  Presenting to Win</text>
+<text x="514.0" y="1519.0" font-size="13.5" font-weight="540" fill="#334155">150  The Art of the Pitch</text>
+<text x="514.0" y="1544.0" font-size="13.5" font-weight="540" fill="#334155">151  Pitch Anything</text>
+<text x="514.0" y="1569.0" font-size="13.5" font-weight="540" fill="#334155">152  Talk Like TED</text>
+<text x="514.0" y="1594.0" font-size="13.5" font-weight="540" fill="#334155">153  Think Faster, Talk Smarter</text>
+<text x="514.0" y="1619.0" font-size="13.5" font-weight="540" fill="#334155">154  TED Talks</text>
+<text x="514.0" y="1644.0" font-size="13.5" font-weight="540" fill="#334155">155  Crucial Conversations</text>
+<text x="514.0" y="1669.0" font-size="13.5" font-weight="540" fill="#334155">156  Influencer</text>
+<text x="514.0" y="1694.0" font-size="13.5" font-weight="540" fill="#334155">157  Nonviolent Communication</text>
+<text x="514.0" y="1719.0" font-size="13.5" font-weight="540" fill="#334155">158  The First Minute</text>
+<text x="514.0" y="1744.0" font-size="13.5" font-weight="540" fill="#334155">159  Smart Brevity</text>
+<rect x="912.0" y="1528.0" width="396.0" height="326.0" rx="14" fill="#FFFFFF" stroke="#D8E0EA"/>
+<rect x="912.0" y="1528.0" width="6" height="326.0" rx="3" fill="#2563EB"/>
+<text x="934.0" y="1563.0" font-size="18" font-weight="700" fill="#0F172A">战略、商业与数据</text>
+<text x="1286.0" y="1563.0" text-anchor="end" font-size="13" class="mono" fill="#64748B">10 ITEMS</text>
+<text x="934.0" y="1595.0" font-size="13.5" font-weight="540" fill="#334155">160  Financial Intelligence</text>
+<text x="934.0" y="1620.0" font-size="13.5" font-weight="540" fill="#334155">161  Getting to Plan B</text>
+<text x="934.0" y="1645.0" font-size="13.5" font-weight="540" fill="#334155">162  Business Model Generation</text>
+<text x="934.0" y="1670.0" font-size="13.5" font-weight="540" fill="#334155">163  Good Strategy/Bad Strategy</text>
+<text x="934.0" y="1695.0" font-size="13.5" font-weight="540" fill="#334155">164  Blue Ocean Strategy</text>
+<text x="934.0" y="1720.0" font-size="13.5" font-weight="540" fill="#334155">165  Crossing the Chasm</text>
+<text x="934.0" y="1745.0" font-size="13.5" font-weight="540" fill="#334155">166  Diffusion of Innovations</text>
+<text x="934.0" y="1770.0" font-size="13.5" font-weight="540" fill="#334155">167  Zone to Win</text>
+<text x="934.0" y="1795.0" font-size="13.5" font-weight="540" fill="#334155">168  Competing on Analytics</text>
+<text x="934.0" y="1820.0" font-size="13.5" font-weight="540" fill="#334155">169  How to Measure Anything</text>
+<rect x="72.0" y="1557.0" width="396.0" height="496.0" rx="14" fill="#FFFFFF" stroke="#D8E0EA"/>
+<rect x="72.0" y="1557.0" width="6" height="496.0" rx="3" fill="#2563EB"/>
+<text x="94.0" y="1592.0" font-size="18" font-weight="700" fill="#0F172A">中文销售实战</text>
+<text x="446.0" y="1592.0" text-anchor="end" font-size="13" class="mono" fill="#64748B">16 ITEMS</text>
+<text x="94.0" y="1624.0" font-size="13.5" font-weight="540" fill="#334155">170  跟华尔街之狼学销售</text>
+<text x="94.0" y="1649.0" font-size="13.5" font-weight="540" fill="#334155">171  销售洗脑</text>
+<text x="94.0" y="1674.0" font-size="13.5" font-weight="540" fill="#334155">172  销售话术全能一本通</text>
+<text x="94.0" y="1699.0" font-size="13.5" font-weight="540" fill="#334155">173  利他成交：销冠高情商话术</text>
+<text x="94.0" y="1724.0" font-size="13.5" font-weight="540" fill="#334155">174  高效签单</text>
+<text x="94.0" y="1749.0" font-size="13.5" font-weight="540" fill="#334155">175  成为销冠</text>
+<text x="94.0" y="1774.0" font-size="13.5" font-weight="540" fill="#334155">176  从相识到成交</text>
+<text x="94.0" y="1799.0" font-size="13.5" font-weight="540" fill="#334155">177  直销管理条例</text>
+<text x="94.0" y="1824.0" font-size="13.5" font-weight="540" fill="#334155">178  禁止传销条例</text>
+<text x="94.0" y="1849.0" font-size="13.5" font-weight="540" fill="#334155">179  纵横</text>
+<text x="94.0" y="1874.0" font-size="13.5" font-weight="540" fill="#334155">180  价值型销售</text>
+<text x="94.0" y="1899.0" font-size="13.5" font-weight="540" fill="#334155">181  通关</text>
+<text x="94.0" y="1924.0" font-size="13.5" font-weight="540" fill="#334155">182  阿里铁军：阿里巴巴销售铁军的进化、</text>
+<text x="94.0" y="1944.0" font-size="13.5" font-weight="420" fill="#475569">裂变与复制</text>
+<text x="94.0" y="1969.0" font-size="13.5" font-weight="540" fill="#334155">183  阿里铁军销售课</text>
+<text x="94.0" y="1994.0" font-size="13.5" font-weight="540" fill="#334155">184  阿里铁军销售法</text>
+<text x="94.0" y="2019.0" font-size="13.5" font-weight="540" fill="#334155">185  销售铁军</text>
+<rect x="1332.0" y="1788.0" width="396.0" height="591.0" rx="14" fill="#FFFFFF" stroke="#D8E0EA"/>
+<rect x="1332.0" y="1788.0" width="6" height="591.0" rx="3" fill="#2563EB"/>
+<text x="1354.0" y="1823.0" font-size="18" font-weight="700" fill="#0F172A">中国经营、法规与标准</text>
+<text x="1706.0" y="1823.0" text-anchor="end" font-size="13" class="mono" fill="#64748B">19 ITEMS</text>
+<text x="1354.0" y="1855.0" font-size="13.5" font-weight="540" fill="#334155">186  乡土中国</text>
+<text x="1354.0" y="1880.0" font-size="13.5" font-weight="540" fill="#334155">187  置身事内：中国政府与经济发展</text>
+<text x="1354.0" y="1905.0" font-size="13.5" font-weight="540" fill="#334155">188  转型中的地方政府</text>
+<text x="1354.0" y="1930.0" font-size="13.5" font-weight="540" fill="#334155">189  互联网营销师国家职业技能标准</text>
+<text x="1354.0" y="1955.0" font-size="13.5" font-weight="540" fill="#334155">190  中华人民共和国民法典</text>
+<text x="1354.0" y="1980.0" font-size="13.5" font-weight="540" fill="#334155">191  中华人民共和国反不正当竞争法</text>
+<text x="1354.0" y="2005.0" font-size="13.5" font-weight="540" fill="#334155">192  中华人民共和国广告法</text>
+<text x="1354.0" y="2030.0" font-size="13.5" font-weight="540" fill="#334155">193  互联网广告管理办法</text>
+<text x="1354.0" y="2055.0" font-size="13.5" font-weight="540" fill="#334155">194  中华人民共和国个人信息保护法</text>
+<text x="1354.0" y="2080.0" font-size="13.5" font-weight="540" fill="#334155">195  中华人民共和国数据安全法</text>
+<text x="1354.0" y="2105.0" font-size="13.5" font-weight="540" fill="#334155">196  中华人民共和国网络安全法</text>
+<text x="1354.0" y="2130.0" font-size="13.5" font-weight="540" fill="#334155">197  中华人民共和国电子商务法</text>
+<text x="1354.0" y="2155.0" font-size="13.5" font-weight="540" fill="#334155">198  中华人民共和国消费者权益保护法</text>
+<text x="1354.0" y="2180.0" font-size="13.5" font-weight="540" fill="#334155">199  中华人民共和国招标投标法</text>
+<text x="1354.0" y="2205.0" font-size="13.5" font-weight="540" fill="#334155">200</text>
+<text x="1354.0" y="2225.0" font-size="13.5" font-weight="420" fill="#475569">关于在政府采购中实施本国产品标准及相关政策的通</text>
+<text x="1354.0" y="2245.0" font-size="13.5" font-weight="420" fill="#475569">知</text>
+<text x="1354.0" y="2270.0" font-size="13.5" font-weight="540" fill="#334155">201  合规管理体系 要求及使用指南</text>
+<text x="1354.0" y="2295.0" font-size="13.5" font-weight="540" fill="#334155">202  中华人民共和国民营经济促进法</text>
+<text x="1354.0" y="2320.0" font-size="13.5" font-weight="540" fill="#334155">203  优化营商环境条例</text>
+<text x="1354.0" y="2345.0" font-size="13.5" font-weight="540" fill="#334155">204  中华人民共和国外商投资法</text>
+<line x1="72" y1="2431" x2="1728" y2="2431" stroke="#CBD5E1"/>
+<text x="72" y="2457" font-size="12" fill="#64748B">XIAOGUAN · LOCAL SALES COPILOT · github.com/powerycy/xiaoguan</text>
+<text x="1728" y="2457" text-anchor="end" font-size="12" fill="#64748B">CATALOG SNAPSHOT 2026-08-25</text>
+</svg>

--- a/docs/library-catalog.md
+++ b/docs/library-catalog.md
@@ -1,0 +1,259 @@
+# 销冠资料库完整目录
+
+> 数据快照：2026-08-25。共204项书籍、课程、报告、法规与标准目录记录，全部来自本地《B端销冠Skill第一轮资料库清单》与元数据索引。
+
+204项是**研究书目/课程目录**，不代表付费商业作品全文被纳入公开仓库。公开仓库不包含本地语料本体、向量模型或生成后的索引。
+
+## 精简后的可检索语料
+
+- 候选池：34,486,518 Unicode 字符
+- 当前保留：16,802,204 Unicode 字符
+- 体积减少：51.3%
+- 保留资料：403份
+- 混合索引：15,473个可检索分片（已去除1,877个重复分片）
+
+## 行为决策与心理（20项）
+
+1. Thinking, Fast and Slow
+2. Nudge
+3. Predictably Irrational
+4. The Righteous Mind
+5. How Minds Change
+6. A Theory of Cognitive Dissonance
+7. The Social Animal
+8. Social Beings
+9. Presence
+10. Self-Efficacy
+11. Mindset
+12. Grit
+13. Drive
+14. To Sell Is Human
+15. Behave
+16. The Status Game
+17. Games People Play
+18. Fooled by Randomness
+19. Superforecasting
+20. Thinking in Bets
+
+## 组织、权力与变革（15项）
+
+21. Power: Why Some People Have It—and Others Don’t
+22. 7 Rules of Power
+23. Influence Without Authority
+24. Power and Influence
+25. The First 90 Days
+26. Flying Without a Net
+27. Working Identity
+28. Forget a Mentor, Find a Sponsor
+29. Never Eat Alone
+30. Give and Take
+31. Structural Holes
+32. Organizational Culture and Leadership
+33. Overcoming Organizational Defenses
+34. Immunity to Change
+35. Leading Change
+
+## 顾问式销售与价值（17项）
+
+36. SPIN Selling Fieldbook
+37. Questions That Sell
+38. Secrets of Question-Based Selling
+39. Insight Selling
+40. Rainmaking Conversations
+41. The Only Sales Guide You’ll Ever Need
+42. Elite Sales Strategies
+43. The Qualified Sales Leader
+44. Command of the Message
+45. The Science of Selling
+46. Sales Presentations for Dummies
+47. Sell Different!
+48. How Clients Buy
+49. Power Questions
+50. Clients for Life
+51. The Win Without Pitching Manifesto
+52. Pricing Creativity
+
+## 大客户与采购（8项）
+
+53. Key Account Management
+54. Key Account Planning
+55. Key Account Management and Planning
+56. Handbook of Strategic Account Management
+57. Strategic Selling
+58. Beyond the Sales Process
+59. Supplier Relationship Management
+60. Category Management in Purchasing
+
+## 谈判、定价与成交（18项）
+
+61. Bargaining for Advantage
+62. Negotiation Genius
+63. Getting Past No
+64. The Power of a Positive No
+65. Negotiating for Success
+66. You Can Negotiate Anything
+67. Start with No
+68. Secrets of Power Negotiating
+69. Negotiating with Backbone
+70. Confessions of the Pricing Man
+71. Monetizing Innovation
+72. The Strategy and Tactics of Pricing
+73. Objections
+74. Sales EQ
+75. Ink the Deal
+76. Secrets of Closing the Sale
+77. How to Master the Art of Selling
+78. How I Raised Myself from Failure to Success in Selling
+
+## 销售心理与直销（12项）
+
+79. Way of the Wolf
+80. The Psychology of Selling
+81. Advanced Selling Strategies
+82. Sell or Be Sold
+83. The Closer’s Survival Guide
+84. The 10X Rule
+85. The Little Red Book of Selling
+86. How to Sell Anything to Anybody
+87. The Greatest Salesman in the World
+88. No Thanks, I’m Just Looking
+89. The Psychology of Persuasion
+90. Direct Selling for Dummies
+
+## 中国商业与关系（7项）
+
+91. Capitalism with Chinese Characteristics
+92. China’s Gilded Age
+93. How China Escaped the Poverty Trap
+94. Chinese Business Negotiating Style
+95. Guanxi and Business
+96. Chinese Commercial Negotiating Style
+97. The Culture Map
+
+## 内容、品牌与 ABM（19项）
+
+98. The New Rules of Marketing and PR
+99. They Ask, You Answer
+100. Everybody Writes
+101. Epic Content Marketing
+102. Content Inc
+103. Managing Content Marketing
+104. Building a StoryBrand
+105. Contagious
+106. Jab, Jab, Jab, Right Hook
+107. Social Selling
+108. Social Selling Mastery
+109. Full Funnel Marketing
+110. Account-Based Marketing for Dummies
+111. ABM Is B2B
+112. The ABM Effect
+113. Lost and Founder
+114. How Brands Grow
+115. Building Distinctive Brand Assets
+116. The Long and the Short of It
+
+## 销售增长与 RevOps（10项）
+
+117. Predictable Revenue
+118. The Sales Acceleration Formula
+119. Blueprints for a SaaS Sales Organization
+120. Revenue Operations
+121. Predictable Prospecting
+122. The Sales Development Playbook
+123. New Sales. Simplified
+124. Sales Truth
+125. State of Sales, 7th Edition
+126. 2026 Global B2B Pulse
+
+## 客户成功与体验（16项）
+
+127. Customer Success
+128. Customer Success: How Innovative Companies Are Reducing Churn
+129. Customer Success: The Book
+130. The Customer Success Professional’s Handbook
+131. Practical Customer Success Management
+132. Onboarding Matters
+133. Never Lose a Customer Again
+134. Chief Customer Officer 2.0
+135. Customer Experience 3.0
+136. Strategic Customer Service
+137. The Loyalty Effect
+138. Winning on Purpose
+139. The Effortless Experience
+140. Uplifting Service
+141. Unreasonable Hospitality
+142. Kaleidoscope
+
+## 表达、呈现与沟通（17项）
+
+143. The Pyramid Principle
+144. Resonate
+145. Slide:ology
+146. DataStory
+147. Storytelling with Data
+148. Presentation Zen
+149. Presenting to Win
+150. The Art of the Pitch
+151. Pitch Anything
+152. Talk Like TED
+153. Think Faster, Talk Smarter
+154. TED Talks
+155. Crucial Conversations
+156. Influencer
+157. Nonviolent Communication
+158. The First Minute
+159. Smart Brevity
+
+## 战略、商业与数据（10项）
+
+160. Financial Intelligence
+161. Getting to Plan B
+162. Business Model Generation
+163. Good Strategy/Bad Strategy
+164. Blue Ocean Strategy
+165. Crossing the Chasm
+166. Diffusion of Innovations
+167. Zone to Win
+168. Competing on Analytics
+169. How to Measure Anything
+
+## 中文销售实战（16项）
+
+170. 跟华尔街之狼学销售
+171. 销售洗脑
+172. 销售话术全能一本通
+173. 利他成交：销冠高情商话术
+174. 高效签单
+175. 成为销冠
+176. 从相识到成交
+177. 直销管理条例
+178. 禁止传销条例
+179. 纵横
+180. 价值型销售
+181. 通关
+182. 阿里铁军：阿里巴巴销售铁军的进化、裂变与复制
+183. 阿里铁军销售课
+184. 阿里铁军销售法
+185. 销售铁军
+
+## 中国经营、法规与标准（19项）
+
+186. 乡土中国
+187. 置身事内：中国政府与经济发展
+188. 转型中的地方政府
+189. 互联网营销师国家职业技能标准
+190. 中华人民共和国民法典
+191. 中华人民共和国反不正当竞争法
+192. 中华人民共和国广告法
+193. 互联网广告管理办法
+194. 中华人民共和国个人信息保护法
+195. 中华人民共和国数据安全法
+196. 中华人民共和国网络安全法
+197. 中华人民共和国电子商务法
+198. 中华人民共和国消费者权益保护法
+199. 中华人民共和国招标投标法
+200. 关于在政府采购中实施本国产品标准及相关政策的通知
+201. 合规管理体系 要求及使用指南
+202. 中华人民共和国民营经济促进法
+203. 优化营商环境条例
+204. 中华人民共和国外商投资法


### PR DESCRIPTION
## Summary

- remove the License section from both README versions
- add a complete visual catalog covering all 204 research entries
- add the searchable text catalog
- surface verified corpus curation metrics: 34,486,518 → 16,802,204 Unicode characters (−51.3%), 403 retained sources, and 15,473 searchable chunks

## Verification

- README pair validation passed
- Skill structure validation passed
- all 204 catalog titles are unique and present in the text catalog
- SVG covers entries 001–204 and parses as valid XML
- final SVG inspected at full 1800 × 2477 resolution
- Python scripts compile successfully
- git diff check passed