### PR TITLE
chore: migrate project to community org

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,131 @@
+# PolyForm Noncommercial License 1.0.0
+
+<https://polyformproject.org/licenses/noncommercial/1.0.0>
+
+## Acceptance
+
+In order to get any license under these terms, you must agree
+to them as both strict obligations and conditions to all
+your licenses.
+
+## Copyright License
+
+The licensor grants you a copyright license for the
+software to do everything you might do with the software
+that would otherwise infringe the licensor's copyright
+in it for any permitted purpose.  However, you may
+only distribute the software according to [Distribution
+License](#distribution-license) and make changes or new works
+based on the software according to [Changes and New Works
+License](#changes-and-new-works-license).
+
+## Distribution License
+
+The licensor grants you an additional copyright license
+to distribute copies of the software.  Your license
+to distribute covers distributing the software with
+changes and new works permitted by [Changes and New Works
+License](#changes-and-new-works-license).
+
+## Notices
+
+You must ensure that anyone who gets a copy of any part of
+the software from you also gets a copy of these terms or the
+URL for them above, as well as copies of any plain-text lines
+beginning with `Required Notice:` that the licensor provided
+with the software.  For example:
+
+> Required Notice: Copyright Yoyodyne, Inc. (http://example.com)
+
+## Changes and New Works License
+
+The licensor grants you an additional copyright license to
+make changes and new works based on the software for any
+permitted purpose.
+
+## Patent License
+
+The licensor grants you a patent license for the software that
+covers patent claims the licensor can license, or becomes able
+to license, that you would infringe by using the software.
+
+## Noncommercial Purposes
+
+Any noncommercial purpose is a permitted purpose.
+
+## Personal Uses
+
+Personal use for research, experiment, and testing for
+the benefit of public knowledge, personal study, private
+entertainment, hobby projects, amateur pursuits, or religious
+observance, without any anticipated commercial application,
+is use for a permitted purpose.
+
+## Noncommercial Organizations
+
+Use by any charitable organization, educational institution,
+public research organization, public safety or health
+organization, environmental protection organization,
+or government institution is use for a permitted purpose
+regardless of the source of funding or obligations resulting
+from the funding.
+
+## Fair Use
+
+You may have "fair use" rights for the software under the
+law. These terms do not limit them.
+
+## No Other Rights
+
+These terms do not allow you to sublicense or transfer any of
+your licenses to anyone else, or prevent the licensor from
+granting licenses to anyone else.  These terms do not imply
+any other licenses.
+
+## Patent Defense
+
+If you make any written claim that the software infringes or
+contributes to infringement of any patent, your patent license
+for the software granted under these terms ends immediately. If
+your company makes such a claim, your patent license ends
+immediately for work on behalf of your company.
+
+## Violations
+
+The first time you are notified in writing that you have
+violated any of these terms, or done anything with the software
+not covered by your licenses, your licenses can nonetheless
+continue if you come into full compliance with these terms,
+and take practical steps to correct past violations, within
+32 days of receiving notice.  Otherwise, all your licenses
+end immediately.
+
+## No Liability
+
+***As far as the law allows, the software comes as is, without
+any warranty or condition, and the licensor will not be liable
+to you for any damages arising out of these terms or the use
+or nature of the software, under any kind of legal claim.***
+
+## Definitions
+
+The **licensor** is the individual or entity offering these
+terms, and the **software** is the software the licensor makes
+available under these terms.
+
+**You** refers to the individual or entity agreeing to these
+terms.
+
+**Your company** is any legal entity, sole proprietorship,
+or other kind of organization that you work for, plus all
+organizations that have control over, are under the control of,
+or are under common control with that organization.  **Control**
+means ownership of substantially all the assets of an entity,
+or the power to direct its management and policies by vote,
+contract, or otherwise.  Control can be direct or indirect.
+
+**Your licenses** are all the licenses granted to you for the
+software under these terms.
+
+**Use** means anything you do with the software requiring one
+of your licenses.

--- a/README.md
+++ b/README.md
@@ -11,13 +11,14 @@
 </p>
 
 <p align="center">
-  <a href="https://github.com/powerycy/xiaoguan/stargazers"><strong>⭐ 如果销冠解决了你的实际销售问题，点亮 Star 方便收藏，也让更多销售发现它</strong></a>
+  <a href="https://github.com/shengjidaguai-china/xiaoguan/stargazers"><strong>⭐ 如果销冠解决了你的实际销售问题，点亮 Star 方便收藏，也让更多销售发现它</strong></a>
 </p>
 
 <p align="center">
-  <a href="https://github.com/powerycy/xiaoguan/stargazers"><img src="https://img.shields.io/github/stars/powerycy/xiaoguan?style=flat-square" alt="GitHub Stars"></a>
-  <a href="https://github.com/powerycy/xiaoguan/issues"><img src="https://img.shields.io/github/issues/powerycy/xiaoguan?style=flat-square" alt="GitHub Issues"></a>
-  <a href="https://github.com/powerycy/xiaoguan/commits/main"><img src="https://img.shields.io/github/last-commit/powerycy/xiaoguan?style=flat-square" alt="Last Commit"></a>
+  <a href="https://github.com/shengjidaguai-china/xiaoguan/stargazers"><img src="https://img.shields.io/github/stars/shengjidaguai-china/xiaoguan?style=flat-square" alt="GitHub Stars"></a>
+  <a href="https://github.com/shengjidaguai-china/xiaoguan/issues"><img src="https://img.shields.io/github/issues/shengjidaguai-china/xiaoguan?style=flat-square" alt="GitHub Issues"></a>
+  <a href="https://github.com/shengjidaguai-china/xiaoguan/commits/main"><img src="https://img.shields.io/github/last-commit/shengjidaguai-china/xiaoguan?style=flat-square" alt="Last Commit"></a>
+  <a href="./LICENSE"><img src="https://img.shields.io/badge/license-PolyForm%20Noncommercial%201.0.0-blue?style=flat-square" alt="PolyForm Noncommercial License 1.0.0"></a>
   <a href="./SKILL.md"><img src="https://img.shields.io/badge/Codex-Skill-111827?style=flat-square" alt="Codex Skill"></a>
   <a href="https://www.python.org/"><img src="https://img.shields.io/badge/Python-3.10%2B-3776AB?style=flat-square&logo=python&logoColor=white" alt="Python 3.10+"></a>
 </p>
@@ -76,7 +77,7 @@
 ### 1. 安装 Skill
 
 ```bash
-git clone https://github.com/powerycy/xiaoguan.git ~/.codex/skills/xiaoguan
+git clone https://github.com/shengjidaguai-china/xiaoguan.git ~/.codex/skills/xiaoguan
 ```
 
 已经安装过时：
@@ -201,8 +202,14 @@ xiaoguan/
 
 ## 参与项目
 
-如果你发现某类客户判断不准、销售阶段路由不合适，或有可复现的改进建议，欢迎提交 [Issue](https://github.com/powerycy/xiaoguan/issues) 或 Pull Request。请不要在 Issue 中上传真实客户姓名、联系方式、聊天全文或商业机密。
+销冠现已迁入[升级打怪开源社区](https://github.com/shengjidaguai-china)，由 [@powerycy](https://github.com/powerycy) 负责维护。如果你发现某类客户判断不准、销售阶段路由不合适，或有可复现的改进建议，欢迎提交 [Issue](https://github.com/shengjidaguai-china/xiaoguan/issues) 或 Pull Request。新成员可以从带有 [`good first issue`](https://github.com/shengjidaguai-china/xiaoguan/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) 标签的任务开始。
+
+请不要在 Issue 中上传真实客户姓名、联系方式、聊天全文或商业机密。社区贡献还应遵守[行为准则](https://github.com/shengjidaguai-china/.github/blob/main/CODE_OF_CONDUCT.md)和[参与规则](https://github.com/shengjidaguai-china/.github/blob/main/CONTRIBUTING.md)。
+
+## 许可证
+
+本项目采用 [PolyForm Noncommercial License 1.0.0](./LICENSE)。个人学习、研究、实验以及符合许可证定义的非商业用途可以使用、修改和分发；商业使用不在本许可证授权范围内，需要另行取得许可。
 
 ---
 
-如果销冠对你有用，可以 [点亮 Star](https://github.com/powerycy/xiaoguan/stargazers) 收藏项目；想跟进更新可 Watch，有问题或改进建议请直接提 Issue。
+如果销冠对你有用，可以 [点亮 Star](https://github.com/shengjidaguai-china/xiaoguan/stargazers) 收藏项目；想跟进更新可 Watch，有问题或改进建议请直接提 Issue。

--- a/README_EN.md
+++ b/README_EN.md
@@ -11,13 +11,14 @@
 </p>
 
 <p align="center">
-  <a href="https://github.com/powerycy/xiaoguan/stargazers"><strong>⭐ If Xiaoguan helps with a real sales problem, Star it for later and help other sellers discover it</strong></a>
+  <a href="https://github.com/shengjidaguai-china/xiaoguan/stargazers"><strong>⭐ If Xiaoguan helps with a real sales problem, Star it for later and help other sellers discover it</strong></a>
 </p>
 
 <p align="center">
-  <a href="https://github.com/powerycy/xiaoguan/stargazers"><img src="https://img.shields.io/github/stars/powerycy/xiaoguan?style=flat-square" alt="GitHub Stars"></a>
-  <a href="https://github.com/powerycy/xiaoguan/issues"><img src="https://img.shields.io/github/issues/powerycy/xiaoguan?style=flat-square" alt="GitHub Issues"></a>
-  <a href="https://github.com/powerycy/xiaoguan/commits/main"><img src="https://img.shields.io/github/last-commit/powerycy/xiaoguan?style=flat-square" alt="Last Commit"></a>
+  <a href="https://github.com/shengjidaguai-china/xiaoguan/stargazers"><img src="https://img.shields.io/github/stars/shengjidaguai-china/xiaoguan?style=flat-square" alt="GitHub Stars"></a>
+  <a href="https://github.com/shengjidaguai-china/xiaoguan/issues"><img src="https://img.shields.io/github/issues/shengjidaguai-china/xiaoguan?style=flat-square" alt="GitHub Issues"></a>
+  <a href="https://github.com/shengjidaguai-china/xiaoguan/commits/main"><img src="https://img.shields.io/github/last-commit/shengjidaguai-china/xiaoguan?style=flat-square" alt="Last Commit"></a>
+  <a href="./LICENSE"><img src="https://img.shields.io/badge/license-PolyForm%20Noncommercial%201.0.0-blue?style=flat-square" alt="PolyForm Noncommercial License 1.0.0"></a>
   <a href="./SKILL.md"><img src="https://img.shields.io/badge/Codex-Skill-111827?style=flat-square" alt="Codex Skill"></a>
   <a href="https://www.python.org/"><img src="https://img.shields.io/badge/Python-3.10%2B-3776AB?style=flat-square&logo=python&logoColor=white" alt="Python 3.10+"></a>
 </p>
@@ -76,7 +77,7 @@ Xiaoguan first catalogued **204 books, courses, reports, regulations, and standa
 ### 1. Install the Skill
 
 ```bash
-git clone https://github.com/powerycy/xiaoguan.git ~/.codex/skills/xiaoguan
+git clone https://github.com/shengjidaguai-china/xiaoguan.git ~/.codex/skills/xiaoguan
 ```
 
 To update an existing installation:
@@ -201,8 +202,14 @@ The project does not currently publish CI, Releases, or coverage metrics, so thi
 
 ## Contributing
 
-If a buyer analysis is consistently wrong, a stage is routed poorly, or you have a reproducible improvement, open an [Issue](https://github.com/powerycy/xiaoguan/issues) or submit a Pull Request. Do not include real customer names, contact details, full private conversations, or confidential business information.
+Xiaoguan is now hosted by the [Sheng Ji Da Guai open-source community](https://github.com/shengjidaguai-china) and maintained by [@powerycy](https://github.com/powerycy). If a buyer analysis is consistently wrong, a stage is routed poorly, or you have a reproducible improvement, open an [Issue](https://github.com/shengjidaguai-china/xiaoguan/issues) or submit a Pull Request. New contributors can start with tasks labeled [`good first issue`](https://github.com/shengjidaguai-china/xiaoguan/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22).
+
+Do not include real customer names, contact details, full private conversations, or confidential business information in an Issue. Community contributions must also follow the [Code of Conduct](https://github.com/shengjidaguai-china/.github/blob/main/CODE_OF_CONDUCT.md) and [contribution guidelines](https://github.com/shengjidaguai-china/.github/blob/main/CONTRIBUTING.md).
+
+## License
+
+This project is licensed under the [PolyForm Noncommercial License 1.0.0](./LICENSE). Personal study, research, experimentation, and other noncommercial purposes defined by the license are permitted. Commercial use requires separate permission.
 
 ---
 
-If Xiaoguan is useful, [Star the repository](https://github.com/powerycy/xiaoguan/stargazers) to keep it close. Watch for updates, or open an Issue with a concrete problem or improvement.
+If Xiaoguan is useful, [Star the repository](https://github.com/shengjidaguai-china/xiaoguan/stargazers) to keep it close. Watch for updates, or open an Issue with a concrete problem or improvement.

--- a/assets/library-catalog.svg
+++ b/assets/library-catalog.svg
@@ -285,6 +285,6 @@
 <text x="1354.0" y="2320.0" font-size="13.5" font-weight="540" fill="#334155">203  优化营商环境条例</text>
 <text x="1354.0" y="2345.0" font-size="13.5" font-weight="540" fill="#334155">204  中华人民共和国外商投资法</text>
 <line x1="72" y1="2431" x2="1728" y2="2431" stroke="#CBD5E1"/>
-<text x="72" y="2457" font-size="12" fill="#64748B">XIAOGUAN · LOCAL SALES COPILOT · github.com/powerycy/xiaoguan</text>
+<text x="72" y="2457" font-size="12" fill="#64748B">XIAOGUAN · LOCAL SALES COPILOT · github.com/shengjidaguai-china/xiaoguan</text>
 <text x="1728" y="2457" text-anchor="end" font-size="12" fill="#64748B">CATALOG SNAPSHOT 2026-08-25</text>
 </svg>


### PR DESCRIPTION
## 这次改变了什么

- 增加 PolyForm Noncommercial License 1.0.0
- 将安装命令、徽章和项目链接更新到升级打怪开源社区
- 补充维护者、社区参与入口和隐私提醒
- 更新资料库全景图中的仓库地址

## 验证

- Skill 结构校验通过
- 四个 Python 脚本通过语法和 CLI 启动检查
- 未包含本地语料、索引、向量模型或客户数据
- 中英文 README 共同事实已同步